### PR TITLE
Dev applications

### DIFF
--- a/test/controller/applicationsController.test.js
+++ b/test/controller/applicationsController.test.js
@@ -38,4 +38,21 @@ describe('Applications Controller', () => {
 
         expect(response.statusCode).toEqual(201);
     })
+
+    it('should return all freelancers applications', async () => {
+        const response = await request(app)
+            .get('/projects/me/applications')
+            .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX25hbWUiOiJqb2huIGRvZSIsInJvbGUiOiJGUkVFTEFOQ0VSIiwiaWF0IjoxNzU1NDM5NzE0LCJleHAiOjE3NTU0NzU3MTR9.ccuNsrvlETd31cAoeDX_g8Rfw58EOMUbIrHUyIqSeno')
+
+        expect(response.statusCode).toEqual(200);
+    })
+
+    it('should return all client applications', async () => {
+        const projectId = 3
+        const response = await request(app)
+            .get(`/projects/${projectId}/applications`)
+            .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoyLCJ1c2VyX25hbWUiOiJqYW5lIGRvZSIsInJvbGUiOiJDTElFTlQiLCJpYXQiOjE3NTU0NDUwNjEsImV4cCI6MTc1NTQ4MTA2MX0.7uZ-5Ztsy9iyJEgJc-ybd7dPVKGvijCJhOmtiVgHBGc')
+
+        expect(response.statusCode).toEqual(200);
+    });
 })

--- a/test/controller/applicationsController.test.js
+++ b/test/controller/applicationsController.test.js
@@ -1,0 +1,41 @@
+import request from 'supertest';
+import app from '../../src/index.js'
+
+describe('Applications Controller', () => {
+    it('should return an error for unauthorized access to apply to client project', async () => {
+        const projectId = 3
+        const response = await request(app)
+            .post(`/projects/${projectId}/applications`)
+
+        expect(response.statusCode).toEqual(401);
+        expect(response.body).toHaveProperty('status', 'error');
+        expect(response.body).toHaveProperty('message', 'Unauthorized access');
+    })
+
+    it('should return an error for forbidden access to non-freelancers', async ()=> {
+        const projectId = 3
+        const response = await request(app)
+            .post(`/projects/${projectId}/applications`)
+            .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoyLCJ1c2VyX25hbWUiOiJqYW5lIGRvZSIsInJvbGUiOiJDTElFTlQiLCJpYXQiOjE3NTU0NDIyMjQsImV4cCI6MTc1NTQ3ODIyNH0.faz5x_HQ2FiNTvau1DsAw_MG9WpjyDQOdm7luTS_kz0')
+            .send({
+                coverLetter: 'I am a freelancer applying for this project.',
+                bidAmount: 100
+            })
+        expect(response.statusCode).toEqual(403);
+        expect(response.body).toHaveProperty('status', 'error');
+        expect(response.body).toHaveProperty('message', 'Forbidden: Only freelancers can apply to projects');
+    })
+
+    it('should return success for authorized access to apply to client project', async () => {
+        const projectId = 3
+        const response = await request(app)
+            .post(`/projects/${projectId}/applications`)
+            .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX25hbWUiOiJqb2huIGRvZSIsInJvbGUiOiJGUkVFTEFOQ0VSIiwiaWF0IjoxNzU1NDM5NzE0LCJleHAiOjE3NTU0NzU3MTR9.ccuNsrvlETd31cAoeDX_g8Rfw58EOMUbIrHUyIqSeno')
+            .send({
+                coverLetter: 'I am a freelancer applying for this project.',
+                bidAmount: 100
+            })
+
+        expect(response.statusCode).toEqual(201);
+    })
+})

--- a/test/controller/applicationsController.test.js
+++ b/test/controller/applicationsController.test.js
@@ -1,5 +1,9 @@
 import request from 'supertest';
 import app from '../../src/index.js'
+import 'dotenv/config.js'
+
+const CLIENT_TOKEN = process.env.CLIENT_JWT
+const FREELANCER_TOKEN = process.env.FREELANCER_JWT
 
 describe('Applications Controller', () => {
     it('should return an error for unauthorized access to apply to client project', async () => {
@@ -16,7 +20,7 @@ describe('Applications Controller', () => {
         const projectId = 3
         const response = await request(app)
             .post(`/projects/${projectId}/applications`)
-            .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoyLCJ1c2VyX25hbWUiOiJqYW5lIGRvZSIsInJvbGUiOiJDTElFTlQiLCJpYXQiOjE3NTU0NDIyMjQsImV4cCI6MTc1NTQ3ODIyNH0.faz5x_HQ2FiNTvau1DsAw_MG9WpjyDQOdm7luTS_kz0')
+            .set('Authorization', CLIENT_TOKEN)
             .send({
                 coverLetter: 'I am a freelancer applying for this project.',
                 bidAmount: 100
@@ -27,10 +31,10 @@ describe('Applications Controller', () => {
     })
 
     it('should return success for authorized access to apply to client project', async () => {
-        const projectId = 3
+        const projectId = 6 // todo: change this to prevent error when testing
         const response = await request(app)
             .post(`/projects/${projectId}/applications`)
-            .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX25hbWUiOiJqb2huIGRvZSIsInJvbGUiOiJGUkVFTEFOQ0VSIiwiaWF0IjoxNzU1NDM5NzE0LCJleHAiOjE3NTU0NzU3MTR9.ccuNsrvlETd31cAoeDX_g8Rfw58EOMUbIrHUyIqSeno')
+            .set('Authorization', FREELANCER_TOKEN)
             .send({
                 coverLetter: 'I am a freelancer applying for this project.',
                 bidAmount: 100
@@ -42,7 +46,7 @@ describe('Applications Controller', () => {
     it('should return all freelancers applications', async () => {
         const response = await request(app)
             .get('/projects/me/applications')
-            .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX25hbWUiOiJqb2huIGRvZSIsInJvbGUiOiJGUkVFTEFOQ0VSIiwiaWF0IjoxNzU1NDM5NzE0LCJleHAiOjE3NTU0NzU3MTR9.ccuNsrvlETd31cAoeDX_g8Rfw58EOMUbIrHUyIqSeno')
+            .set('Authorization', FREELANCER_TOKEN)
 
         expect(response.statusCode).toEqual(200);
     })
@@ -51,7 +55,7 @@ describe('Applications Controller', () => {
         const projectId = 3
         const response = await request(app)
             .get(`/projects/${projectId}/applications`)
-            .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoyLCJ1c2VyX25hbWUiOiJqYW5lIGRvZSIsInJvbGUiOiJDTElFTlQiLCJpYXQiOjE3NTU0NDUwNjEsImV4cCI6MTc1NTQ4MTA2MX0.7uZ-5Ztsy9iyJEgJc-ybd7dPVKGvijCJhOmtiVgHBGc')
+            .set('Authorization', CLIENT_TOKEN)
 
         expect(response.statusCode).toEqual(200);
     });

--- a/test/controller/projectController.test.js
+++ b/test/controller/projectController.test.js
@@ -1,5 +1,9 @@
 import request from 'supertest';
 import app from '../../src/index.js'
+import 'dotenv/config.js'
+
+const CLIENT_TOKEN = process.env.CLIENT_JWT
+const FREELANCER_TOKEN = process.env.FREELANCER_JWT
 
 describe('POST /projects', () =>  {
     it('should return an error for unauthorized access when creating a project', async () => {
@@ -40,7 +44,7 @@ describe('DELETE /projects/:id', () => {
     it('should return an error for unauthorized access when deleting a non-existent project', async () => {
         const projectId = '9999';
 
-        const res = await request(app).delete(`/projects/${projectId}`).set('authorization', "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoyLCJ1c2VyX25hbWUiOiJqYW5lIGRvZSIsInJvbGUiOiJDTElFTlQiLCJpYXQiOjE3NTUzNzQ2NDYsImV4cCI6MTc1NTQxMDY0Nn0.6quoPsOkHBzCJQ4WjxkJR73Jvib853QsHnQtJaJA-Oc");
+        const res = await request(app).delete(`/projects/${projectId}`).set('authorization', CLIENT_TOKEN);
 
         expect(res.statusCode).toEqual(404);
         expect(res.body).toEqual({
@@ -52,7 +56,7 @@ describe('DELETE /projects/:id', () => {
     it('should return an error for forbidden access when deleting a project as a non-client user', async () => {
         const projectId = '1';
         const res = await request(app).delete(`/projects/${projectId}`)
-        .set('authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX25hbWUiOiJqb2huIGRvZSIsInJvbGUiOiJGUkVFTEFOQ0VSIiwiaWF0IjoxNzU1NDEwMTY2LCJleHAiOjE3NTU0NDYxNjZ9.Ta1niJVIjjhNk_ErmDeL7s1otU4X6l0AaZCLDdXFgtA')
+        .set('authorization', FREELANCER_TOKEN)
         expect(res.statusCode).toEqual(403);
         expect(res.body).toEqual({
             message: "Forbidden: Only admin and clients can delete projects",
@@ -64,7 +68,7 @@ describe('DELETE /projects/:id', () => {
         const projectId = 'invalid-id';
 
         const res = await request(app).delete(`/projects/${projectId}`)
-            .set('authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX25hbWUiOiJqb2huIGRvZSIsInJvbGUiOiJGUkVFTEFOQ0VSIiwiaWF0IjoxNzU1NDEwMTY2LCJleHAiOjE3NTU0NDYxNjZ9.Ta1niJVIjjhNk_ErmDeL7s1otU4X6l0AaZCLDdXFgtA')
+            .set('authorization', CLIENT_TOKEN)
 
 
         expect(res.statusCode).toEqual(400);
@@ -78,8 +82,7 @@ describe('DELETE /projects/:id', () => {
     //     const projectId = '2';
     //
     //     const res = await request(app).delete(`/projects/${projectId}`)
-    //         .set('authorization',  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoyLCJ1c2VyX25hbWUiOiJqYW5lIGRvZSIsInJvbGUiOiJDTElFTlQiLCJpYXQiOjE3NTUzNzQ2NDYsImV4cCI6MTc1NTQxMDY0Nn0.6quoPsOkHBzCJQ4WjxkJR73Jvib853QsHnQtJaJA-Oc",
-    //         );
+    //         .set('authorization',  CLIENT_TOKEN);
     //
     //     expect(res.statusCode).toEqual(200);
     //     expect(res.body).toEqual({
@@ -94,7 +97,7 @@ describe('GET /projects', () => {
         const projectId = 'invalid-id';
 
         const res = await request(app).get(`/projects/${projectId}`)
-            .set('authorization', "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoyLCJ1c2VyX25hbWUiOiJqYW5lIGRvZSIsInJvbGUiOiJDTElFTlQiLCJpYXQiOjE3NTUzNzQ2NDYsImV4cCI6MTc1NTQxMDY0Nn0.6quoPsOkHBzCJQ4WjxkJR73Jvib853QsHnQtJaJA-Oc");
+            .set('authorization', CLIENT_TOKEN);
 
         expect(res.statusCode).toEqual(400);
         expect(res.body).toEqual({
@@ -117,7 +120,7 @@ describe('GET /projects', () => {
         const projectId = '5';
 
         const res = await request(app).get(`/projects/${projectId}`)
-            .set('authorization', "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoyLCJ1c2VyX25hbWUiOiJqYW5lIGRvZSIsInJvbGUiOiJDTElFTlQiLCJpYXQiOjE3NTUzNzQ2NDYsImV4cCI6MTc1NTQxMDY0Nn0.6quoPsOkHBzCJQ4WjxkJR73Jvib853QsHnQtJaJA-Oc");
+            .set('authorization', CLIENT_TOKEN);
 
         expect(res.statusCode).toEqual(200);
         expect(res.body).toEqual({
@@ -140,7 +143,7 @@ describe('GET /projects', () => {
 
     it('should return success for retrieving all projects', async () => {
         const res = await request(app).get('/projects')
-            .set('authorization', "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX25hbWUiOiJqb2huIGRvZSIsInJvbGUiOiJGUkVFTEFOQ0VSIiwiaWF0IjoxNzU1NDEwMTY2LCJleHAiOjE3NTU0NDYxNjZ9.Ta1niJVIjjhNk_ErmDeL7s1otU4X6l0AaZCLDdXFgtA");
+            .set('authorization', CLIENT_TOKEN);
         expect(res.statusCode).toEqual(200);
         expect(res.body).toEqual({
             "message": "Projects retrieved successfully",
@@ -156,10 +159,10 @@ describe('PATCH /projects/:id/:status', () => {
         const projectId = '4';
 
         const res = await request(app).patch(`/projects/${projectId}/close`)
-            .set('authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoyLCJ1c2VyX25hbWUiOiJqYW5lIGRvZSIsInJvbGUiOiJDTElFTlQiLCJpYXQiOjE3NTU0MTE2MjYsImV4cCI6MTc1NTQ0NzYyNn0.8cdZ_CkjjGlgSBk4qtB0DGuf25SgWWkbcsLGJBimHgQ');
+            .set('authorization', CLIENT_TOKEN);
         expect(res.statusCode).toEqual(200);
         expect(res.body).toEqual({
-            message: "Project status updated closed successfully",  
+            message: "Project status updated to CLOSED",
             status: "success"
         })
     })
@@ -168,10 +171,10 @@ describe('PATCH /projects/:id/:status', () => {
         const projectId = '4';
 
         const res = await request(app).patch(`/projects/${projectId}/open`)
-            .set('authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoyLCJ1c2VyX25hbWUiOiJqYW5lIGRvZSIsInJvbGUiOiJDTElFTlQiLCJpYXQiOjE3NTU0MTE2MjYsImV4cCI6MTc1NTQ0NzYyNn0.8cdZ_CkjjGlgSBk4qtB0DGuf25SgWWkbcsLGJBimHgQ');
+            .set('authorization', CLIENT_TOKEN);
         expect(res.statusCode).toEqual(200);
         expect(res.body).toEqual({
-            message: "Project status updated successfully",
+            message: "Project status updated to open",
             status: "success",
         })
     })


### PR DESCRIPTION
This pull request adds application management features for projects, improves role-based access control, and updates tests to use environment-based JWT tokens for better maintainability and security. The most important changes are grouped below.

**New application management features:**

* Added three new endpoints to `projectRouter` in `projectController.js`:
  - POST `/projects/:id/applications`: Allows freelancers to apply to projects with a cover letter and bid amount, including validation and error handling.
  - GET `/projects/me/applications`: Lets freelancers view all their applications.
  - GET `/projects/:id/applications`: Allows clients and admins to view all applications for a specific project, including freelancer details.

**Role-based access control improvements:**

* Fixed the logic in the project deletion endpoint to correctly restrict access to only clients and admins.
* Enforced role checks for the new application endpoints to ensure only authorized roles can access them.

**Testing enhancements:**

* Added a new test suite `applicationsController.test.js` to cover application submission and retrieval scenarios, including authorization and validation errors.
* Refactored `projectController.test.js` to use `CLIENT_TOKEN` and `FREELANCER_TOKEN` from environment variables instead of hardcoded JWTs, improving maintainability and security. [[1]](diffhunk://#diff-9c2fe1e06290a44d150e9b71d661c6046b53ff85ee695a283914bbaf959776bbR3-R6) [[2]](diffhunk://#diff-9c2fe1e06290a44d150e9b71d661c6046b53ff85ee695a283914bbaf959776bbL43-R47) [[3]](diffhunk://#diff-9c2fe1e06290a44d150e9b71d661c6046b53ff85ee695a283914bbaf959776bbL55-R59) [[4]](diffhunk://#diff-9c2fe1e06290a44d150e9b71d661c6046b53ff85ee695a283914bbaf959776bbL67-R71) [[5]](diffhunk://#diff-9c2fe1e06290a44d150e9b71d661c6046b53ff85ee695a283914bbaf959776bbL81-R85) [[6]](diffhunk://#diff-9c2fe1e06290a44d150e9b71d661c6046b53ff85ee695a283914bbaf959776bbL97-R100) [[7]](diffhunk://#diff-9c2fe1e06290a44d150e9b71d661c6046b53ff85ee695a283914bbaf959776bbL120-R123) [[8]](diffhunk://#diff-9c2fe1e06290a44d150e9b71d661c6046b53ff85ee695a283914bbaf959776bbL143-R146) [[9]](diffhunk://#diff-9c2fe1e06290a44d150e9b71d661c6046b53ff85ee695a283914bbaf959776bbL159-R165) [[10]](diffhunk://#diff-9c2fe1e06290a44d150e9b71d661c6046b53ff85ee695a283914bbaf959776bbL171-R177)